### PR TITLE
ld_conf.rs: remove extra 'match' in parse_ld_so_conf()

### DIFF
--- a/src/ld_conf.rs
+++ b/src/ld_conf.rs
@@ -4,19 +4,14 @@ use std::io::{self, BufRead};
 use std::path::Path;
 
 pub fn parse_ld_so_conf(filename: &Path) -> Result<Vec<String>, &'static str> {
-    let lines = match read_lines(filename) {
+    let mut lines = match read_lines(filename) {
         Ok(lines) => lines,
         Err(_e) => return Err("Could not open the filename"),
     };
 
     let mut r = <Vec<String>>::new();
 
-    for line in lines {
-        let entry = match line {
-            Ok(entry) => entry,
-            _ => break,
-        };
-
+    while let Some(Ok(entry)) = lines.next() {
         // Remove leading whitespace.
         let entry = entry.trim_start();
         // Remove trailing comments.


### PR DESCRIPTION
We can use 'while let' with a Some(Ok()) pattern to read each string of the 'lines' iterator or stop if there's no more strings to be read.

Since we're consuming the iterator via .next() we need to change it to mutable.

Signed-off-by: Daniel Henrique Barboza <danielhb413@gmail.com>