### PR TITLE
Azanella/android support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "fastrand"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -48,6 +63,15 @@ name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "libc"
@@ -107,6 +131,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "rldd"
 version = "0.2.0"
 dependencies = [
@@ -116,6 +158,7 @@ dependencies = [
  "memmap2",
  "object",
  "raw-cpuid",
+ "tempfile",
  "termcolor",
 ]
 
@@ -128,6 +171,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ glob = "0.3.0"
 termcolor = "1.1.3"
 argh = "0.1.9"
 
-[target.'cfg(target_os = "macos")'.dependencies]
+[target.'cfg(any(target_os = "macos", target_os = "android"))'.dependencies]
 libc = "0.2.138"
 
 [target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ libc = "0.2.138"
 [target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
 raw-cpuid = "10.6.0"
 
+[target.'cfg(target_os = "android")'.dev-dependencies]
+tempfile = "3.3.0"
+
 [profile.release]
 strip = true
 opt-level = "z"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # rldd
 
-The rldd tool resolves and prints the binary or shared library dependencies with different visualization options.  Similar to the Linux ldd tool, it does not invoke the system loader but instead parses the loading information directly from either ELF or Mach-O files.
+The rldd tool resolves and prints the binary or shared library dependencies with different visualization options.  Similar to the Linux ldd tool, it does not invoke the system loader but instead parses the loading information directly from either ELF or Mach-O files, along with any required system files (such as loader cache or extra configuration files).
 
-Currently it supports Linux, FreeBSD, OpenBSD, NetBSD, Illumos (no support for crle/ld.config, trusted directories, or any environment variable), and macOS.
+Currently it supports Linux (glibc, android, and musl), FreeBSD, OpenBSD, NetBSD, Illumos (no support for crle/ld.config, trusted directories, or any environment variable), and macOS.
 
 ![screenshot](doc/screenshot.png)
 

--- a/TODO.md
+++ b/TODO.md
@@ -23,3 +23,4 @@
 - [x] Linux: read /etc/ld.so.cache instead of parsing /etd/ld.so.conf.
 - [x] Implement DYLD_INSERT_LIBRARIES.
 - [x] Linux: add [glibc-hwcap support](https://sourceware.org/pipermail/libc-alpha/2020-June/115250.html), which affects symbol resolution paths fro x86_64, powerpc64, aarch64, and s390-64.
+- [x] Linux: add Android support.

--- a/src/deptree.rs
+++ b/src/deptree.rs
@@ -62,6 +62,8 @@ impl fmt::Display for DepMode {
             DepMode::DtRunpath => write!(f, "[runpath]"),
             #[cfg(target_os = "linux")]
             DepMode::LdCache => write!(f, "[ld.so.cache]"),
+            #[cfg(target_os = "android")]
+            DepMode::LdCache => write!(f, "[ld.config.txt]"),
             #[cfg(target_os = "freebsd")]
             DepMode::LdCache => write!(f, "[ld-elf.so.hints]"),
             #[cfg(target_os = "openbsd")]

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -446,7 +446,7 @@ fn match_elf_name(melc: &ElfInfo, dtneeded: Option<&String>, elc: &ElfInfo) -> b
     true
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn check_elf_header(elc: &ElfInfo) -> bool {
     // TODO: ARM also accepts ELFOSABI_SYSV
     elc.ei_osabi == ELFOSABI_SYSV || elc.ei_osabi == ELFOSABI_GNU
@@ -624,6 +624,10 @@ fn load_so_cache(elc: &ElfInfo) -> Option<ld_so_cache::LdCache> {
             Err(e) => eprintln!("error: load_so_cache: {}", e),
         }
     };
+    None
+}
+#[cfg(target_os = "android")]
+fn load_so_cache(_elc: &ElfInfo) -> Option<Vec<search_path::SearchPath>> {
     None
 }
 #[cfg(target_os = "freebsd")]

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -14,6 +14,8 @@ use crate::search_path;
 
 mod system_dirs;
 
+#[cfg(target_os = "android")]
+mod android;
 #[cfg(target_os = "linux")]
 mod interp;
 #[cfg(target_os = "freebsd")]

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -595,7 +595,7 @@ pub fn resolve_binary(
     let system_dirs = if load_system_dirs(&*ld_cache) {
         match system_dirs::get_system_dirs(&elc.interp, elc.e_machine, elc.ei_class) {
             Some(r) => r,
-            None => return Err(Error::new(ErrorKind::Other, "Invalid ELF architcture")),
+            None => return Err(Error::new(ErrorKind::Other, "could not get the default system dirs")),
         }
     } else {
         search_path::SearchPathVec::new()

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -577,7 +577,7 @@ pub fn resolve_binary(
     // We need a new vector for the case of binaries with different interpreters.
     preload.extend(load_ld_so_preload(&elc.interp));
 
-    let system_dirs = match system_dirs::get_system_dirs(elc.e_machine, elc.ei_class) {
+    let system_dirs = match system_dirs::get_system_dirs(&elc.interp, elc.e_machine, elc.ei_class) {
         Some(r) => r,
         None => return Err(Error::new(ErrorKind::Other, "Invalid ELF architcture")),
     };

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -930,7 +930,11 @@ fn resolve_dependency_ld_cache<'a>(
         }
 
         for linked_ns in &default_ns.namespaces {
-            if let Some(namespace) = ld_cache.get_namespace(&linked_ns.name) {
+            if let Some(namespace) = ld_cache.get_namespace(&linked_ns) {
+                if !namespace.is_accessible(dtneeded) {
+                    continue;
+                }
+
                 if let Some(resolved) = search_namespace(namespace) {
                     return Some(resolved);
                 }

--- a/src/elf/android.rs
+++ b/src/elf/android.rs
@@ -1,22 +1,28 @@
+use object::elf::*;
 use std::ffi::CString;
 use std::io::{Error, ErrorKind};
 
+use crate::pathutils;
+
 pub enum AndroidRelease {
-    AndroidR26 = 26,
-    AndroidR27 = 27,
-    AndroidR28 = 28,
-    AndroidR29 = 29,
-    AndroidR30 = 30,
-    AndroidR31 = 31,
-    AndroidR32 = 32,
-    AndroidR33 = 33,
-    AndroidR34 = 34,
+    AndroidR26 = 26, // 8.0
+    AndroidR27 = 27, // 8.1
+    AndroidR28 = 28, // 9.0
+    AndroidR29 = 29, // 10
+    AndroidR30 = 30, // 11
+    AndroidR31 = 31, // 12
+    AndroidR32 = 32, // 12.1
+    AndroidR33 = 33, // 13
+    AndroidR34 = 34, // 14
 }
 
 const PROP_VALUE_MAX: usize = 92;
 
-pub fn get_release() -> Result<AndroidRelease, std::io::Error> {
-    let name = CString::new("ro.build.version.sdk")?;
+pub fn get_property<S1: AsRef<str>, S2: AsRef<str>>(
+    property: S1,
+    default: S2,
+) -> Result<String, std::io::Error> {
+    let name = CString::new(property.as_ref())?;
 
     let mut val: Vec<libc::c_uchar> = vec![0; PROP_VALUE_MAX];
     let ret = unsafe {
@@ -26,14 +32,16 @@ pub fn get_release() -> Result<AndroidRelease, std::io::Error> {
         return Err(std::io::Error::last_os_error());
     }
 
-    let androidrelease = match val.len() {
-        0 => Err(Error::new(ErrorKind::Other, "Invalid Android release")),
+    match val.len() {
+        0 => Ok(default.as_ref().to_string()),
         l => std::str::from_utf8(&val[..l - 1])
             .map_err(|_e| Error::new(ErrorKind::Other, "Invalid UTF8 sequence"))
-            .and_then(|s| Ok(s.trim_matches(char::from(0)))),
-    }?;
+            .and_then(|s| Ok(s.trim_matches(char::from(0)).to_string())),
+    }
+}
 
-    match androidrelease {
+pub fn get_release() -> Result<AndroidRelease, std::io::Error> {
+    match get_property("ro.build.version.sdk", "")?.as_str() {
         "26" => Ok(AndroidRelease::AndroidR26),
         "27" => Ok(AndroidRelease::AndroidR27),
         "28" => Ok(AndroidRelease::AndroidR28),
@@ -44,5 +52,57 @@ pub fn get_release() -> Result<AndroidRelease, std::io::Error> {
         "33" => Ok(AndroidRelease::AndroidR33),
         "34" => Ok(AndroidRelease::AndroidR34),
         _ => Err(Error::new(ErrorKind::Other, "Unsupported Android release")),
+    }
+}
+
+pub fn get_property_bool<S: AsRef<str>>(
+    property: S,
+    default: bool,
+) -> Result<bool, std::io::Error> {
+    match get_property(property, "")?.as_str() {
+        "1" | "y" | "yes" | "on" | "true" => Ok(true),
+        "0" | "n" | "no" | "off" | "false" => Ok(false),
+        _ => Ok(default),
+    }
+}
+
+pub fn get_vndk_version_string<S: AsRef<str>>(default: S) -> String {
+    match get_property("ro.vndk.version", "") {
+        Ok(value) => value,
+        Err(_) => default.as_ref().to_string(),
+    }
+}
+
+pub fn is_asan<S: AsRef<str>>(interp: S) -> bool {
+    match pathutils::get_name(&std::path::Path::new(interp.as_ref())).as_str() {
+        "linker_asan" | "linker_asan64" => true,
+        _ => false,
+    }
+}
+
+pub fn libpath(e_machine: u16, ei_class: u8) -> Option<&'static str> {
+    match e_machine {
+        EM_AARCH64 | EM_X86_64 => Some("lib64"),
+        EM_ARM | EM_386 => Some("lib"),
+        EM_MIPS => match ei_class {
+            ELFCLASS64 => Some("lib64"),
+            ELFCLASS32 => Some("lib"),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+pub fn abi_string(e_machine: u16, ei_class: u8) -> Option<&'static str> {
+    match e_machine {
+        EM_AARCH64 => Some("arm64"),
+        EM_ARM => Some("arm"),
+        EM_X86_64 => Some("x86_64"),
+        EM_386 => Some("x86"),
+        EM_RISCV => match ei_class {
+            ELFCLASS64 => Some("riscv64"),
+            _ => None,
+        },
+        _ => None,
     }
 }

--- a/src/elf/android.rs
+++ b/src/elf/android.rs
@@ -1,0 +1,48 @@
+use std::ffi::CString;
+use std::io::{Error, ErrorKind};
+
+pub enum AndroidRelease {
+    AndroidR26 = 26,
+    AndroidR27 = 27,
+    AndroidR28 = 28,
+    AndroidR29 = 29,
+    AndroidR30 = 30,
+    AndroidR31 = 31,
+    AndroidR32 = 32,
+    AndroidR33 = 33,
+    AndroidR34 = 34,
+}
+
+const PROP_VALUE_MAX: usize = 92;
+
+pub fn get_release() -> Result<AndroidRelease, std::io::Error> {
+    let name = CString::new("ro.build.version.sdk")?;
+
+    let mut val: Vec<libc::c_uchar> = vec![0; PROP_VALUE_MAX];
+    let ret = unsafe {
+        libc::__system_property_get(name.as_ptr(), val.as_mut_ptr() as *mut libc::c_char)
+    };
+    if ret < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+
+    let androidrelease = match val.len() {
+        0 => Err(Error::new(ErrorKind::Other, "Invalid Android release")),
+        l => std::str::from_utf8(&val[..l - 1])
+            .map_err(|_e| Error::new(ErrorKind::Other, "Invalid UTF8 sequence"))
+            .and_then(|s| Ok(s.trim_matches(char::from(0)))),
+    }?;
+
+    match androidrelease {
+        "26" => Ok(AndroidRelease::AndroidR26),
+        "27" => Ok(AndroidRelease::AndroidR27),
+        "28" => Ok(AndroidRelease::AndroidR28),
+        "29" => Ok(AndroidRelease::AndroidR29),
+        "30" => Ok(AndroidRelease::AndroidR30),
+        "31" => Ok(AndroidRelease::AndroidR31),
+        "32" => Ok(AndroidRelease::AndroidR32),
+        "33" => Ok(AndroidRelease::AndroidR33),
+        "34" => Ok(AndroidRelease::AndroidR34),
+        _ => Err(Error::new(ErrorKind::Other, "Unsupported Android release")),
+    }
+}

--- a/src/elf/android.rs
+++ b/src/elf/android.rs
@@ -40,8 +40,12 @@ pub fn get_property<S1: AsRef<str>, S2: AsRef<str>>(
     }
 }
 
+pub fn get_release_str() -> Result<String, std::io::Error> {
+    get_property("ro.build.version.sdk", "").and_then(|s| Ok(s.to_string()))
+}
+
 pub fn get_release() -> Result<AndroidRelease, std::io::Error> {
-    match get_property("ro.build.version.sdk", "")?.as_str() {
+    match get_release_str()?.as_str() {
         "26" => Ok(AndroidRelease::AndroidR26),
         "27" => Ok(AndroidRelease::AndroidR27),
         "28" => Ok(AndroidRelease::AndroidR28),

--- a/src/elf/android.rs
+++ b/src/elf/android.rs
@@ -1,6 +1,7 @@
 use object::elf::*;
 use std::ffi::CString;
 use std::io::{Error, ErrorKind};
+use std::fmt;
 
 use crate::pathutils;
 
@@ -14,6 +15,23 @@ pub enum AndroidRelease {
     AndroidR32 = 32, // 12.1
     AndroidR33 = 33, // 13
     AndroidR34 = 34, // 14
+}
+
+impl fmt::Display for AndroidRelease {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match &self {
+            AndroidRelease::AndroidR26 => fmt.write_str("26")?,
+            AndroidRelease::AndroidR27 => fmt.write_str("27")?,
+            AndroidRelease::AndroidR28 => fmt.write_str("28")?,
+            AndroidRelease::AndroidR29 => fmt.write_str("29")?,
+            AndroidRelease::AndroidR30 => fmt.write_str("30")?,
+            AndroidRelease::AndroidR31 => fmt.write_str("31")?,
+            AndroidRelease::AndroidR32 => fmt.write_str("32")?,
+            AndroidRelease::AndroidR33 => fmt.write_str("33")?,
+            AndroidRelease::AndroidR34 => fmt.write_str("34")?,
+        };
+        Ok(())
+    }
 }
 
 const PROP_VALUE_MAX: usize = 92;

--- a/src/elf/android.rs
+++ b/src/elf/android.rs
@@ -1,11 +1,13 @@
 use object::elf::*;
 use std::ffi::CString;
-use std::io::{Error, ErrorKind};
 use std::fmt;
+use std::io::{Error, ErrorKind};
 
 use crate::pathutils;
 
 pub enum AndroidRelease {
+    AndroidR24 = 24, // 7.0
+    AndroidR25 = 25, // 7.1
     AndroidR26 = 26, // 8.0
     AndroidR27 = 27, // 8.1
     AndroidR28 = 28, // 9.0
@@ -20,6 +22,8 @@ pub enum AndroidRelease {
 impl fmt::Display for AndroidRelease {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match &self {
+            AndroidRelease::AndroidR24 => fmt.write_str("24")?,
+            AndroidRelease::AndroidR25 => fmt.write_str("25")?,
             AndroidRelease::AndroidR26 => fmt.write_str("26")?,
             AndroidRelease::AndroidR27 => fmt.write_str("27")?,
             AndroidRelease::AndroidR28 => fmt.write_str("28")?,
@@ -64,6 +68,8 @@ pub fn get_release_str() -> Result<String, std::io::Error> {
 
 pub fn get_release() -> Result<AndroidRelease, std::io::Error> {
     match get_release_str()?.as_str() {
+        "24" => Ok(AndroidRelease::AndroidR24),
+        "25" => Ok(AndroidRelease::AndroidR25),
         "26" => Ok(AndroidRelease::AndroidR26),
         "27" => Ok(AndroidRelease::AndroidR27),
         "28" => Ok(AndroidRelease::AndroidR28),

--- a/src/elf/ld_config_txt.rs
+++ b/src/elf/ld_config_txt.rs
@@ -100,7 +100,12 @@ impl Properties for HashMap<String, String> {
         if let Ok(sdk_ver) = get_release_str() {
             path = path.replace("${SDK_VER}", sdk_ver.as_str());
         }
-        // TODO Add VNDK_VER support
+
+        path = path.replace(
+            "${VNDK_VER}",
+            format!("-{}", get_vndk_version_string("")).as_str(),
+        );
+
         // TODO Add VNDK_APEX_VER support (the expansion depends on release version)
 
         path = path.replace("${LIB}", lib);

--- a/src/elf/ld_config_txt.rs
+++ b/src/elf/ld_config_txt.rs
@@ -26,10 +26,6 @@ pub struct NamespaceConfig {
     pub namespaces: NamespaceLinkingConfigVec,
 }
 
-pub trait NamespaceConfigTrait {
-    fn push_namespace(&mut self, name: &str) -> &Self;
-}
-
 const DEFAULT_NAME_CONFIG: &str = "default";
 
 pub type LdCacheNs = HashMap<String, NamespaceConfig>;
@@ -58,9 +54,7 @@ impl LdCache {
     fn config_set(&self) -> HashSet<String> {
         self.namespaces_config.keys().cloned().collect()
     }
-}
 
-impl NamespaceConfigTrait for LdCache {
     fn push_namespace(&mut self, name: &str) -> &Self {
         self.namespaces_config.insert(
             name.to_string(),

--- a/src/elf/ld_config_txt.rs
+++ b/src/elf/ld_config_txt.rs
@@ -237,6 +237,9 @@ pub fn get_ld_config_path<P: AsRef<Path>>(
 
     if let Ok(release) = get_release() {
         return match release {
+            // Android 7.0/7.1 does not support ld.config.txt.
+            AndroidRelease::AndroidR24 | AndroidRelease::AndroidR25 => None,
+
             // Android 8.0/8.1 has the ld.config.txt hardcoded.
             AndroidRelease::AndroidR26 | AndroidRelease::AndroidR27 => get_default_ld_config_path(),
 

--- a/src/elf/ld_config_txt.rs
+++ b/src/elf/ld_config_txt.rs
@@ -1,0 +1,691 @@
+use std::collections::{HashMap, HashSet};
+use std::ffi::OsStr;
+use std::fs::File;
+use std::io::{self, BufRead};
+use std::path::Path;
+
+use crate::elf::android::*;
+use crate::pathutils;
+use crate::search_path;
+
+#[derive(Debug)]
+pub struct NamespaceLinkingConfig {
+    name: String,
+    shared_libs: String,
+    allow_all: bool,
+}
+pub type NamespaceLinkingConfigVec = Vec<NamespaceLinkingConfig>;
+
+#[derive(Debug)]
+pub struct NamespaceConfig {
+    name: String,
+    isolated: bool,
+    visible: bool,
+    search_paths: search_path::SearchPathVec,
+    permitted: search_path::SearchPathVec,
+    allowed_libs: Vec<String>,
+    namespaces: NamespaceLinkingConfigVec,
+}
+
+pub trait NamespaceConfigTrait {
+    fn push_namespace(&mut self, name: &str) -> &Self;
+}
+
+const DEFAULT_NAME_CONFIG: &str = "default";
+
+pub trait LdCacheTraits {
+    fn get_default_namespace(&self) -> Option<&NamespaceConfig>;
+}
+
+pub type LdCache = HashMap<String, NamespaceConfig>;
+
+impl LdCacheTraits for LdCache {
+    fn get_default_namespace(&self) -> Option<&NamespaceConfig> {
+        self.get(DEFAULT_NAME_CONFIG)
+    }
+}
+
+impl NamespaceConfigTrait for LdCache {
+    fn push_namespace(&mut self, name: &str) -> &Self {
+        self.insert(
+            name.to_string(),
+            NamespaceConfig {
+                name: name.to_string(),
+                isolated: false,
+                visible: false,
+                search_paths: search_path::SearchPathVec::new(),
+                permitted: search_path::SearchPathVec::new(),
+                allowed_libs: Vec::<String>::new(),
+                namespaces: NamespaceLinkingConfigVec::new(),
+            },
+        );
+        self
+    }
+}
+
+pub trait Properties {
+    fn get_bool<S: AsRef<str>>(&self, name: S) -> bool;
+    fn get_string<S: AsRef<str>>(&self, name: S) -> String;
+    fn get_paths<S: AsRef<str>>(
+        &self,
+        name: S,
+        e_machine: u16,
+        ei_class: u8,
+    ) -> search_path::SearchPathVec;
+}
+
+impl Properties for HashMap<String, String> {
+    fn get_bool<S: AsRef<str>>(&self, name: S) -> bool {
+        self.get(name.as_ref())
+            .and_then(|s| Some(s == "true"))
+            .unwrap_or(false)
+    }
+
+    fn get_string<S: AsRef<str>>(&self, name: S) -> String {
+        self.get(name.as_ref())
+            .unwrap_or(&"".to_string())
+            .to_string()
+    }
+
+    fn get_paths<S: AsRef<str>>(
+        &self,
+        name: S,
+        e_machine: u16,
+        ei_class: u8,
+    ) -> search_path::SearchPathVec {
+        let mut path = self.get_string(name);
+
+        let lib = libpath(e_machine, ei_class).unwrap();
+
+        // TODO Add SDK_VER support
+        // TODO Add VNDK_VER support
+        // TODO Add VNDK_APEX_VER support (the expansion depends on release version)
+
+        path = path.replace("${LIB}", lib);
+
+        search_path::from_string(path, &[':'])
+    }
+}
+
+#[derive(Debug)]
+enum Token {
+    PropertyAssign,
+    PropertyAppend,
+    Section,
+    Error,
+}
+
+pub fn get_ld_config_path<P: AsRef<Path>>(
+    executable: &P,
+    e_machine: u16,
+    ei_class: u8,
+) -> Option<String> {
+    fn get_ld_config_vndk_path() -> String {
+        if get_property_bool("ro.vndk.lite", false).unwrap() {
+            return "/system/etc/ld.config.vndk_lite.txt".to_string();
+        }
+
+        format!("/system/etc/ld.config.{}.txt", get_vndk_version_string(""))
+    }
+
+    fn get_default_ld_config_path() -> Option<String> {
+        Some("/system/etc/ld.config.txt".to_string())
+    }
+
+    fn get_vndk_ld_config_path(e_machine: u16, ei_class: u8, linkerconfig: bool) -> Option<String> {
+        if let Some(abi) = abi_string(e_machine, ei_class) {
+            let ld_config_arch = format!("/system/etc/ld.config.{}.txt", abi);
+            if Path::new(&ld_config_arch).exists() {
+                return Some(ld_config_arch);
+            }
+        }
+
+        if linkerconfig {
+            let linkerconfig_path = "/linkerconfig/ld.config.txt".to_string();
+            if Path::new(&linkerconfig_path).exists() {
+                return Some(linkerconfig_path);
+            }
+        }
+
+        let vndk_config = get_ld_config_vndk_path();
+        if Path::new(&vndk_config).exists() {
+            return Some(vndk_config);
+        }
+
+        get_default_ld_config_path()
+    }
+
+    fn get_apex_ld_config_path<P: AsRef<Path>>(
+        executable: &P,
+        linkerconfig: bool,
+    ) -> Option<String> {
+        let parts: Vec<&OsStr> = executable.as_ref().iter().collect();
+        if parts.len() == 5 && parts[1] == "apex" && parts[3] == "bin" {
+            let name = parts[2].to_string_lossy();
+            if linkerconfig {
+                let linkerconfig_path = format!("/linkerconfig/{}/ld.config.txt)", name);
+                if Path::new(&linkerconfig_path).exists() {
+                    return Some(linkerconfig_path);
+                }
+            }
+            let apex_config = format!("/apex/{}/etc/ld.config.txt", name);
+            if Path::new(&apex_config).exists() {
+                return Some(apex_config);
+            }
+        }
+        None
+    }
+
+    if let Ok(release) = get_release() {
+        return match release {
+            // Android 8.0/8.1 has the ld.config.txt hardcoded.
+            AndroidRelease::AndroidR26 | AndroidRelease::AndroidR27 => get_default_ld_config_path(),
+
+            // Android 9 added support for abi and vndk specific path.
+            AndroidRelease::AndroidR28 => get_vndk_ld_config_path(e_machine, ei_class, false),
+
+            // Android 10 added support per binary ld.config.txt.
+            AndroidRelease::AndroidR29 => {
+                if let Some(cfg) = get_apex_ld_config_path(executable, false) {
+                    return Some(cfg);
+                }
+                get_vndk_ld_config_path(e_machine, ei_class, false)
+            }
+
+            // Android 11 added the /linkerconfig folder support.
+            AndroidRelease::AndroidR30
+            | AndroidRelease::AndroidR31
+            | AndroidRelease::AndroidR32
+            | AndroidRelease::AndroidR33
+            | AndroidRelease::AndroidR34 => {
+                if let Some(cfg) = get_apex_ld_config_path(executable, true) {
+                    return Some(cfg);
+                }
+                get_vndk_ld_config_path(e_machine, ei_class, true)
+            }
+        };
+    }
+    None
+}
+
+pub fn parse_ld_config_txt<P1: AsRef<Path>, P2: AsRef<Path>, S: AsRef<str>>(
+    filename: &P2,
+    binary: &P1,
+    interp: S,
+    e_machine: u16,
+    ei_class: u8,
+) -> Result<LdCache, &'static str> {
+    let mut lines = match read_lines(filename) {
+        Ok(lines) => lines,
+        Err(_e) => return Err("Could not open the filename"),
+    };
+
+    let section = find_initial_section(binary, &mut lines)?;
+
+    find_section(&section, &mut lines)?;
+
+    let mut properties = HashMap::<String, String>::new();
+    while let Some(Ok(line)) = lines.next() {
+        let (token, line) = match next_token(&line) {
+            Some(fields) => fields,
+            None => continue,
+        };
+        match token {
+            Token::PropertyAssign => {
+                let (name, value) = parse_assignment(&line)?;
+                properties.insert(name.to_string(), value.to_string());
+            }
+            Token::PropertyAppend => {
+                let (name, value) = parse_append(&line)?;
+                if let Some(vec) = properties.get_mut(name) {
+                    let sep = if name.ends_with(".links") || name.ends_with(".namespaces") {
+                        ','
+                    } else if name.ends_with(".paths")
+                        || name.ends_with(".shared_libs")
+                        || name.ends_with(".whitelisted")
+                        || name.ends_with(".allowed_libs")
+                    {
+                        ':'
+                    } else {
+                        continue;
+                    };
+                    vec.push_str(&format!("{}{}", sep, value).to_string());
+                } else {
+                    properties.insert(name.to_string(), value.to_string());
+                }
+            }
+            Token::Section | Token::Error => break,
+        }
+    }
+
+    let mut ns_configs = LdCache::new();
+
+    ns_configs.push_namespace(DEFAULT_NAME_CONFIG);
+
+    if let Some(additional_namespaces) = properties.get("additional.namespaces") {
+        for namespace in additional_namespaces.split(',') {
+            ns_configs.push_namespace(namespace);
+        }
+    }
+
+    // TODO: handle sdk version
+    if properties.get_bool("enable.target.sdk.version") {}
+
+    // The loop below borrow as immutable, so it can not check if the linked namespace
+    // is within the ns_configs.  To accomplish a different set with only ns_config
+    // keys is used.
+    let ns_configs_set: HashSet<String> = ns_configs.keys().cloned().collect();
+
+    let is_asan = is_asan(interp);
+
+    for (_, ns) in ns_configs.iter_mut() {
+        let mut property_name_prefix = format!("namespace.{}", ns.name);
+        if let Some(linked_namespaces) = properties.get(&format!("{}.links", property_name_prefix))
+        {
+            for ns_linked in linked_namespaces.split(',') {
+                if !ns_configs_set.contains(ns_linked) {
+                    return Err("undefined namespace");
+                }
+
+                let allow_all = properties.get_bool(format!(
+                    "{}.link.{}.allow_all_shared_libs",
+                    property_name_prefix, ns_linked
+                ));
+
+                let shared_libs = properties.get_string(format!(
+                    "{}.link.{}.shared_libs",
+                    property_name_prefix, ns_linked
+                ));
+
+                if !allow_all && shared_libs.is_empty() {
+                    return Err("list of shared_libs is not specified or is empty.");
+                }
+
+                if allow_all && !shared_libs.is_empty() {
+                    return Err("both shared_libs and allow_all_shared_libs are set.");
+                }
+
+                ns.namespaces.push(NamespaceLinkingConfig {
+                    name: ns_linked.to_string(),
+                    shared_libs: shared_libs,
+                    allow_all: allow_all,
+                });
+            }
+        }
+
+        ns.isolated = properties.get_bool(format!("{}.isolated", property_name_prefix));
+        ns.visible = properties.get_bool(format!("{}.visible", property_name_prefix));
+
+        // Android r31 added 'allowed_libs' as synonym for 'whitelisted'.
+        let mut allowed_libs: Vec<String> = properties
+            .get_string(format!("{}.whitelisted", property_name_prefix))
+            .split(':')
+            .map(|s| s.to_string())
+            .filter(|x| !x.is_empty())
+            .collect();
+        allowed_libs.append(&mut properties
+            .get_string(format!("{}.allowed_libs", property_name_prefix))
+            .split(':')
+            .map(|s| s.to_string())
+            .filter(|x| !x.is_empty())
+            .collect());
+        ns.allowed_libs = allowed_libs;
+
+        if is_asan {
+            property_name_prefix.push_str(".asan");
+        }
+
+        ns.search_paths = properties.get_paths(
+            format!("{}.search.paths", property_name_prefix),
+            e_machine,
+            ei_class,
+        );
+
+        ns.permitted = properties.get_paths(
+            format!("{}.permitted.paths", property_name_prefix),
+            e_machine,
+            ei_class,
+        );
+    }
+
+    Ok(ns_configs)
+}
+
+fn find_initial_section<P: AsRef<Path>>(
+    binary: &P,
+    lines: &mut io::Lines<io::BufReader<File>>,
+) -> Result<String, &'static str> {
+    while let Some(Ok(line)) = lines.next() {
+        let (token, line) = match next_token(&line) {
+            Some(fields) => fields,
+            None => continue,
+        };
+        // Bionic loader ignore ill formatted lines.
+        match token {
+            Token::PropertyAssign => {
+                let (name, value) = parse_assignment(&line)?;
+                if !name.starts_with("dir.") {
+                    continue;
+                }
+
+                if let Ok(resolved) = std::fs::canonicalize(value) {
+                    if pathutils::file_is_under_dir(binary, &resolved) {
+                        //  Skip the "dir."
+                        return Ok(name[4..].to_string());
+                    }
+                }
+            }
+            Token::Section => break,
+            Token::PropertyAppend | Token::Error => continue,
+        }
+    }
+    Err("initial section for binary not found")
+}
+
+fn find_section(
+    section: &String,
+    lines: &mut io::Lines<io::BufReader<File>>,
+) -> Result<(), &'static str> {
+    while let Some(Ok(line)) = lines.next() {
+        let (token, line) = match next_token(&line) {
+            Some(line) => line,
+            None => continue,
+        };
+        match token {
+            Token::PropertyAssign | Token::PropertyAppend => continue,
+            Token::Section => {
+                if section == &line {
+                    return Ok(());
+                }
+            }
+            _ => break,
+        }
+    }
+    Err("section for binary not found")
+}
+
+fn read_lines<P>(filename: P) -> io::Result<io::Lines<io::BufReader<File>>>
+where
+    P: AsRef<Path>,
+{
+    let file = File::open(filename)?;
+    Ok(io::BufReader::new(file).lines())
+}
+
+fn next_token(line: &String) -> Option<(Token, String)> {
+    // Remove leading whitespace.
+    let line = line.trim_start();
+    // Remove trailing comments.
+    let comment = match line.find('#') {
+        Some(comment) => comment,
+        None => line.len(),
+    };
+    let line = &line[0..comment];
+    // Remove trailing whitespaces.
+    let line = line.trim_end();
+    // Skip empty lines.
+    if line.is_empty() {
+        return None;
+    }
+
+    if line.starts_with('[') && line.ends_with(']') {
+        return Some((Token::Section, line[1..line.len() - 1].to_string()));
+    } else if line.contains("+=") {
+        return Some((Token::PropertyAppend, line.to_string()));
+    } else if line.contains("=") {
+        return Some((Token::PropertyAssign, line.to_string()));
+    }
+
+    Some((Token::Error, line.to_string()))
+}
+
+fn parse_assignment(line: &String) -> Result<(&str, &str), &'static str> {
+    let vec: Vec<&str> = line.split("=").collect();
+    if vec.len() != 2 {
+        return Err("invalid assigment line");
+    }
+    Ok((vec[0].trim(), vec[1].trim()))
+}
+
+fn parse_append(line: &String) -> Result<(&str, &str), &'static str> {
+    let vec: Vec<&str> = line.split("+=").collect();
+    if vec.len() != 2 {
+        return Err("invalid append line");
+    }
+    Ok((vec[0].trim(), vec[1].trim()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use object::elf::*;
+    use std::fs;
+    use std::fs::File;
+    use std::io::{Error, ErrorKind, Write};
+    use std::iter::zip;
+    use tempfile::TempDir;
+
+    fn create_cfg(tmp_path: &str) -> String {
+        format!(
+            "# comment \n\
+      dir.test = {base}\n\
+      \n\
+      [test]\n\
+      \n\
+      enable.target.sdk.version = true\n\
+      additional.namespaces=system\n\
+      additional.namespaces+=vndk\n\
+      additional.namespaces+=vndk_in_system\n\
+      namespace.default.isolated = true\n\
+      namespace.default.search.paths = {base}/vendor/${{LIB}}\n\
+      namespace.default.permitted.paths = {base}/vendor/${{LIB}}\n\
+      namespace.default.asan.search.paths = {base}/data\n\
+      namespace.default.asan.search.paths += {base}/vendor/${{LIB}}\n\
+      namespace.default.asan.permitted.paths = {base}/data:{base}/vendor\n\
+      namespace.default.links = system\n\
+      namespace.default.links += vndk\n\
+      namespace.default.link.system.shared_libs=  libc.so\n\
+      namespace.default.link.system.shared_libs +=   libm.so:libdl.so\n\
+      namespace.default.link.system.shared_libs   +=libstdc++.so\n\
+      namespace.default.link.vndk.shared_libs = libcutils.so:libbase.so\n\
+      namespace.system.isolated = true\n\
+      namespace.system.visible = true\n\
+      namespace.system.search.paths = {base}/system/${{LIB}}\n\
+      namespace.system.permitted.paths = {base}/system/${{LIB}}\n\
+      namespace.system.asan.search.paths = {base}/data:{base}/system/${{LIB}}\n\
+      namespace.system.asan.permitted.paths = {base}/data:{base}/system\n\
+      namespace.vndk.isolated = tr\n\
+      namespace.vndk.isolated += ue\n\
+      namespace.vndk.search.paths = {base}/system/${{LIB}}/vndk\n\
+      namespace.vndk.asan.search.paths = {base}/data\n\
+      namespace.vndk.asan.search.paths += {base}/system/${{LIB}}/vndk\n\
+      namespace.vndk.links = default\n\
+      namespace.vndk.link.default.allow_all_shared_libs = true\n\
+      namespace.vndk.link.vndk_in_system.allow_all_shared_libs = true\n\
+      namespace.vndk_in_system.isolated = true\n\
+      namespace.vndk_in_system.visible = true\n\
+      namespace.vndk_in_system.search.paths = {base}/system/${{LIB}}\n\
+      namespace.vndk_in_system.permitted.paths = {base}/system/${{LIB}}\n\
+      namespace.vndk_in_system.whitelisted = libz.so:libyuv.so:libtinyxml2.so\n\
+      \n",
+            base = tmp_path
+        )
+    }
+
+    fn test_skeleton(is_asan: bool) -> Result<(), std::io::Error> {
+        let interp = match &is_asan {
+            true => "linker_asan",
+            false => "linker",
+        };
+
+        let tmpdir = TempDir::new()?;
+        let cfgpath = tmpdir.path().join("ld.config.txt");
+
+        let dirtest = tmpdir.path().join("tmp");
+        fs::create_dir(&dirtest)?;
+
+        let binpath = dirtest.join("binary");
+        File::create(&binpath)?;
+
+        let vendor = dirtest.join("vendor");
+        fs::create_dir(&vendor)?;
+
+        let vendorlib = dirtest.join("vendor/lib");
+        fs::create_dir(&vendorlib)?;
+
+        let data = dirtest.join("data");
+        fs::create_dir(&data)?;
+
+        let system = dirtest.join("system");
+        fs::create_dir(&system)?;
+
+        let systemlib = dirtest.join("system/lib");
+        fs::create_dir(&systemlib)?;
+
+        let vndklib = dirtest.join("system/lib/vndk");
+        fs::create_dir(&vndklib)?;
+
+        let cfgcontent = create_cfg(&dirtest.to_string_lossy());
+
+        let mut file = File::create(&cfgpath)?;
+        file.write_all(cfgcontent.as_bytes())?;
+
+        let expected_default_search_paths = match &is_asan {
+            true => vec![data.to_str().unwrap(), vendorlib.to_str().unwrap()],
+            false => vec![vendorlib.to_str().unwrap()],
+        };
+        let expected_default_permitted_paths = match &is_asan {
+            true => vec![data.to_str().unwrap(), vendor.to_str().unwrap()],
+            false => vec![vendorlib.to_str().unwrap()],
+        };
+        let expected_system_search_paths = match &is_asan {
+            true => vec![data.to_str().unwrap(), systemlib.to_str().unwrap()],
+            false => vec![systemlib.to_str().unwrap()],
+        };
+        let expected_system_permitted_paths = match &is_asan {
+            true => vec![data.to_str().unwrap(), system.to_str().unwrap()],
+            false => vec![systemlib.to_str().unwrap()],
+        };
+        let expected_vndk_search_paths = match &is_asan {
+            true => vec![data.to_str().unwrap(), vndklib.to_str().unwrap()],
+            false => vec![vndklib.to_str().unwrap()],
+        };
+        let expected_vndk_in_system_search_paths = match &is_asan {
+            true => vec![],
+            false => vec![systemlib.to_str().unwrap()],
+        };
+        let expected_vndk_in_system_permitted_paths = match &is_asan {
+            true => vec![],
+            false => vec![system.to_str().unwrap()],
+        };
+
+        match parse_ld_config_txt(&cfgpath, &binpath, interp, EM_386, ELFCLASS32) {
+            Ok(ldcache) => {
+                let default_ns = ldcache
+                    .get_default_namespace()
+                    .ok_or(Error::new(ErrorKind::Other, "default namespace not found"))?;
+
+                assert_eq!(default_ns.isolated, true);
+                assert_eq!(default_ns.visible, false);
+                assert_eq!(
+                    default_ns.search_paths.len(),
+                    expected_default_search_paths.len()
+                );
+                for (d, e) in zip(&default_ns.search_paths, &expected_default_search_paths) {
+                    assert_eq!(d, e);
+                }
+                assert_eq!(
+                    default_ns.permitted.len(),
+                    expected_default_permitted_paths.len()
+                );
+                for (d, e) in zip(&default_ns.permitted, &expected_default_permitted_paths) {
+                    assert_eq!(d, e);
+                }
+
+                assert_eq!(default_ns.namespaces.len(), 2);
+                assert_eq!(default_ns.namespaces[0].name, "system");
+                assert_eq!(
+                    default_ns.namespaces[0].shared_libs,
+                    "libc.so:libm.so:libdl.so:libstdc++.so"
+                );
+                assert_eq!(default_ns.namespaces[0].allow_all, false);
+                assert_eq!(default_ns.namespaces[1].name, "vndk");
+                assert_eq!(
+                    default_ns.namespaces[1].shared_libs,
+                    "libcutils.so:libbase.so"
+                );
+                assert_eq!(default_ns.namespaces[1].allow_all, false);
+
+                assert_eq!(ldcache.len(), 4);
+
+                let system_ns = ldcache.get("system").unwrap();
+                assert_eq!(system_ns.name, "system");
+                assert_eq!(system_ns.isolated, true);
+                assert_eq!(system_ns.visible, true);
+                assert_eq!(
+                    system_ns.search_paths.len(),
+                    expected_system_search_paths.len()
+                );
+                for (d, e) in zip(&system_ns.search_paths, &expected_system_search_paths) {
+                    assert_eq!(d, e);
+                }
+                assert_eq!(
+                    system_ns.permitted.len(),
+                    expected_system_permitted_paths.len()
+                );
+                for (d, e) in zip(&system_ns.permitted, &expected_system_permitted_paths) {
+                    assert_eq!(d, e);
+                }
+
+                let vndk_ns = ldcache.get("vndk").unwrap();
+                assert_eq!(vndk_ns.name, "vndk");
+                assert_eq!(vndk_ns.isolated, false);
+                assert_eq!(vndk_ns.visible, false);
+                assert_eq!(vndk_ns.search_paths.len(), expected_vndk_search_paths.len());
+                for (d, e) in zip(&vndk_ns.search_paths, &expected_vndk_search_paths) {
+                    assert_eq!(d, e);
+                }
+                assert_eq!(vndk_ns.permitted.len(), 0);
+                assert_eq!(vndk_ns.namespaces.len(), 1);
+                assert_eq!(vndk_ns.namespaces[0].name, "default");
+                assert_eq!(vndk_ns.namespaces[0].allow_all, true);
+
+                let vndk_ns_system = ldcache.get("vndk_in_system").unwrap();
+                assert_eq!(vndk_ns_system.name, "vndk_in_system");
+                assert_eq!(vndk_ns_system.isolated, true);
+                assert_eq!(vndk_ns_system.visible, true);
+                assert_eq!(
+                    vndk_ns_system.search_paths.len(),
+                    expected_vndk_in_system_search_paths.len()
+                );
+                for (d, e) in zip(
+                    &vndk_ns_system.search_paths,
+                    &expected_vndk_in_system_search_paths,
+                ) {
+                    assert_eq!(d, e);
+                }
+                assert_eq!(
+                    vndk_ns_system.permitted.len(),
+                    expected_vndk_in_system_permitted_paths.len()
+                );
+                assert_eq!(
+                    vndk_ns_system.allowed_libs,
+                    vec!["libz.so", "libyuv.so", "libtinyxml2.so"]
+                );
+
+                Ok(())
+            }
+            Err(e) => Err(Error::new(ErrorKind::Other, e)),
+        }
+    }
+
+    #[test]
+    fn smoke() -> Result<(), std::io::Error> {
+        test_skeleton(false)
+    }
+
+    #[test]
+    fn smoke_asan() -> Result<(), std::io::Error> {
+        test_skeleton(true)
+    }
+}

--- a/src/elf/ld_config_txt.rs
+++ b/src/elf/ld_config_txt.rs
@@ -57,19 +57,14 @@ impl LdCache {
     }
 
     pub fn get_namespace<S: AsRef<str>>(&self, name: S) -> Option<&NamespaceConfig> {
-        if let Some(namespace) = self.namespaces_config.get(name.as_ref()) {
-            if namespace.visible {
-                return Some(namespace);
-            }
-        }
-        None
+        self.namespaces_config.get(name.as_ref())
     }
 
     fn config_set(&self) -> HashSet<String> {
         self.namespaces_config.keys().cloned().collect()
     }
 
-    fn push_namespace(&mut self, name: &str) -> &Self {
+    fn push_namespace(&mut self, name: &str) {
         self.namespaces_config.insert(
             name.to_string(),
             NamespaceConfig {
@@ -81,7 +76,6 @@ impl LdCache {
                 namespaces: NamespaceLinkingConfigVec::new(),
             },
         );
-        self
     }
 }
 

--- a/src/elf/ld_config_txt.rs
+++ b/src/elf/ld_config_txt.rs
@@ -101,9 +101,10 @@ impl Properties for HashMap<String, String> {
             path = path.replace("${SDK_VER}", sdk_ver.as_str());
         }
 
-        path = path.replace("${VNDK_VER}", get_vndk_version_str('-').as_str());
+        let vndk_version_str = get_vndk_version_str('-');
 
-        // TODO Add VNDK_APEX_VER support (the expansion depends on release version)
+        path = path.replace("${VNDK_VER}", vndk_version_str.as_str());
+        path = path.replace("${VNDK_APEX_VER}", vndk_version_str.as_str());
 
         path = path.replace("${LIB}", lib);
 

--- a/src/elf/ld_config_txt.rs
+++ b/src/elf/ld_config_txt.rs
@@ -323,12 +323,14 @@ pub fn parse_ld_config_txt<P1: AsRef<Path>, P2: AsRef<Path>, S: AsRef<str>>(
             .map(|s| s.to_string())
             .filter(|x| !x.is_empty())
             .collect();
-        allowed_libs.append(&mut properties
-            .get_string(format!("{}.allowed_libs", property_name_prefix))
-            .split(':')
-            .map(|s| s.to_string())
-            .filter(|x| !x.is_empty())
-            .collect());
+        allowed_libs.append(
+            &mut properties
+                .get_string(format!("{}.allowed_libs", property_name_prefix))
+                .split(':')
+                .map(|s| s.to_string())
+                .filter(|x| !x.is_empty())
+                .collect(),
+        );
         ns.allowed_libs = allowed_libs;
 
         if is_asan {

--- a/src/elf/ld_config_txt.rs
+++ b/src/elf/ld_config_txt.rs
@@ -97,7 +97,9 @@ impl Properties for HashMap<String, String> {
 
         let lib = libpath(e_machine, ei_class).unwrap();
 
-        // TODO Add SDK_VER support
+        if let Ok(sdk_ver) = get_release_str() {
+            path = path.replace("${SDK_VER}", sdk_ver.as_str());
+        }
         // TODO Add VNDK_VER support
         // TODO Add VNDK_APEX_VER support (the expansion depends on release version)
 

--- a/src/elf/ld_config_txt.rs
+++ b/src/elf/ld_config_txt.rs
@@ -5,12 +5,11 @@ use std::io::{self, BufRead};
 use std::path::Path;
 
 use crate::elf::android::*;
-use crate::pathutils;
 use crate::search_path;
 
 #[derive(Debug)]
 pub struct NamespaceLinkingConfig {
-    name: String,
+    pub name: String,
     shared_libs: String,
     allow_all: bool,
 }
@@ -21,10 +20,10 @@ pub struct NamespaceConfig {
     name: String,
     isolated: bool,
     visible: bool,
-    search_paths: search_path::SearchPathVec,
+    pub search_paths: search_path::SearchPathVec,
     permitted: search_path::SearchPathVec,
     allowed_libs: Vec<String>,
-    namespaces: NamespaceLinkingConfigVec,
+    pub namespaces: NamespaceLinkingConfigVec,
 }
 
 pub trait NamespaceConfigTrait {
@@ -50,6 +49,10 @@ impl LdCache {
 
     pub fn get_default_namespace(&self) -> Option<&NamespaceConfig> {
         self.namespaces_config.get(DEFAULT_NAME_CONFIG)
+    }
+
+    pub fn get_namespace<S: AsRef<str>>(&self, name: S) -> Option<&NamespaceConfig> {
+        self.namespaces_config.get(name.as_ref())
     }
 
     fn config_set(&self) -> HashSet<String> {
@@ -435,8 +438,7 @@ fn find_initial_section<P: AsRef<Path>>(
                 }
 
                 if let Ok(resolved) = std::fs::canonicalize(value) {
-                    if pathutils::file_is_under_dir(binary, &resolved) {
-                        //  Skip the "dir."
+                    if binary.as_ref().starts_with(resolved) {
                         return Ok(name[4..].to_string());
                     }
                 }

--- a/src/elf/ld_config_txt.rs
+++ b/src/elf/ld_config_txt.rs
@@ -101,10 +101,7 @@ impl Properties for HashMap<String, String> {
             path = path.replace("${SDK_VER}", sdk_ver.as_str());
         }
 
-        path = path.replace(
-            "${VNDK_VER}",
-            format!("-{}", get_vndk_version_string("")).as_str(),
-        );
+        path = path.replace("${VNDK_VER}", get_vndk_version_str('-').as_str());
 
         // TODO Add VNDK_APEX_VER support (the expansion depends on release version)
 
@@ -122,6 +119,14 @@ enum Token {
     Error,
 }
 
+fn get_vndk_version_str(delimiter: char) -> String {
+    let vndk_str =  get_vndk_version_string("");
+    if vndk_str == "" || vndk_str == "default" {
+        return "".to_string();
+    }
+    format!("{}{}", delimiter, vndk_str)
+}
+
 pub fn get_ld_config_path<P: AsRef<Path>>(
     executable: &P,
     e_machine: u16,
@@ -132,7 +137,7 @@ pub fn get_ld_config_path<P: AsRef<Path>>(
             return "/system/etc/ld.config.vndk_lite.txt".to_string();
         }
 
-        format!("/system/etc/ld.config.{}.txt", get_vndk_version_string(""))
+        format!("/system/etc/ld.config{}.txt", get_vndk_version_str('.'))
     }
 
     fn get_default_ld_config_path() -> Option<String> {

--- a/src/elf/system_dirs.rs
+++ b/src/elf/system_dirs.rs
@@ -69,7 +69,6 @@ pub fn get_system_dirs(
     ei_class: u8,
 ) -> Option<search_path::SearchPathVec> {
     use crate::elf::android;
-    use crate::pathutils;
 
     pub fn get_system_dirs_xx(suffix: &str, is_asan: bool) -> Option<search_path::SearchPathVec> {
         let add_odm = match android::get_release().unwrap() {
@@ -125,10 +124,7 @@ pub fn get_system_dirs(
     }
 
     if let Some(interp) = interp {
-        let is_asan = match pathutils::get_name(&std::path::Path::new(interp)).as_str() {
-            "linker_asan" | "linker_asan64" => true,
-            _ => false,
-        };
+        let is_asan = android::is_asan(interp);
 
         return match e_machine {
             EM_AARCH64 | EM_X86_64 => get_system_dirs_xx("64", is_asan),

--- a/src/elf/system_dirs.rs
+++ b/src/elf/system_dirs.rs
@@ -6,8 +6,6 @@
 ))]
 use object::elf::*;
 
-#[cfg(target_os = "android")]
-use crate::elf::android;
 use crate::search_path;
 
 // Return the default system directory for the architectures and class.  It is hard
@@ -41,7 +39,11 @@ pub fn get_slibdir(e_machine: u16, ei_class: u8) -> Option<&'static str> {
 }
 
 #[cfg(target_os = "linux")]
-pub fn get_system_dirs(e_machine: u16, ei_class: u8) -> Option<search_path::SearchPathVec> {
+pub fn get_system_dirs(
+    _interp: &Option<String>,
+    e_machine: u16,
+    ei_class: u8,
+) -> Option<search_path::SearchPathVec> {
     let path = get_slibdir(e_machine, ei_class)?;
     Some(vec![
         search_path::SearchPath {
@@ -61,53 +63,93 @@ pub fn get_system_dirs(e_machine: u16, ei_class: u8) -> Option<search_path::Sear
 }
 
 #[cfg(target_os = "android")]
-pub fn get_system_dirs_xx(suffix: &str) -> Option<search_path::SearchPathVec> {
-    let add_odm = match android::get_release().unwrap() {
-        android::AndroidRelease::AndroidR28
-        | android::AndroidRelease::AndroidR29
-        | android::AndroidRelease::AndroidR30
-        | android::AndroidRelease::AndroidR31
-        | android::AndroidRelease::AndroidR32
-        | android::AndroidRelease::AndroidR33 => true,
-        _ => false,
-    };
+pub fn get_system_dirs(
+    interp: &Option<String>,
+    e_machine: u16,
+    ei_class: u8,
+) -> Option<search_path::SearchPathVec> {
+    use crate::elf::android;
+    use crate::pathutils;
 
-    let mut r = search_path::SearchPathVec::new();
-    r.push(search_path::SearchPath {
-        path: format!("/system/lib{}", suffix),
-        dev: 0,
-        ino: 0,
-    });
-    if add_odm {
+    pub fn get_system_dirs_xx(suffix: &str, is_asan: bool) -> Option<search_path::SearchPathVec> {
+        let add_odm = match android::get_release().unwrap() {
+            android::AndroidRelease::AndroidR28
+            | android::AndroidRelease::AndroidR29
+            | android::AndroidRelease::AndroidR30
+            | android::AndroidRelease::AndroidR31
+            | android::AndroidRelease::AndroidR32
+            | android::AndroidRelease::AndroidR33 => true,
+            _ => false,
+        };
+
+        let mut r = search_path::SearchPathVec::new();
+        if is_asan {
+            r.push(search_path::SearchPath {
+                path: format!("/data/asan/system/lib{}", suffix),
+                dev: 0,
+                ino: 0,
+            });
+        }
         r.push(search_path::SearchPath {
-            path: format!("/odm/lib{}", suffix),
+            path: format!("/system/lib{}", suffix),
             dev: 0,
             ino: 0,
         });
+        if is_asan && add_odm {
+            r.push(search_path::SearchPath {
+                path: format!("/data/asan/odm/lib{}", suffix),
+                dev: 0,
+                ino: 0,
+            });
+        }
+        if add_odm {
+            r.push(search_path::SearchPath {
+                path: format!("/odm/lib{}", suffix),
+                dev: 0,
+                ino: 0,
+            });
+        }
+        if is_asan {
+            r.push(search_path::SearchPath {
+                path: format!("/data/asan/vendor/lib{}", suffix),
+                dev: 0,
+                ino: 0,
+            });
+        }
+        r.push(search_path::SearchPath {
+            path: format!("/vendor/lib{}", suffix),
+            dev: 0,
+            ino: 0,
+        });
+        Some(r)
     }
-    r.push(search_path::SearchPath {
-        path: format!("/vendor/lib{}", suffix),
-        dev: 0,
-        ino: 0,
-    });
-    Some(r)
-}
-#[cfg(target_os = "android")]
-pub fn get_system_dirs(e_machine: u16, ei_class: u8) -> Option<search_path::SearchPathVec> {
-    match e_machine {
-        EM_AARCH64 | EM_X86_64 => get_system_dirs_xx("64"),
-        EM_ARM | EM_386 => get_system_dirs_xx(""),
-        EM_MIPS => match ei_class {
-            ELFCLASS64 => get_system_dirs_xx("64"),
-            ELFCLASS32 => get_system_dirs_xx(""),
+
+    if let Some(interp) = interp {
+        let is_asan = match pathutils::get_name(&std::path::Path::new(interp)).as_str() {
+            "linker_asan" | "linker_asan64" => true,
+            _ => false,
+        };
+
+        return match e_machine {
+            EM_AARCH64 | EM_X86_64 => get_system_dirs_xx("64", is_asan),
+            EM_ARM | EM_386 => get_system_dirs_xx("", is_asan),
+            EM_MIPS => match ei_class {
+                ELFCLASS64 => get_system_dirs_xx("64", is_asan),
+                ELFCLASS32 => get_system_dirs_xx("", is_asan),
+                _ => None,
+            },
             _ => None,
-        },
-        _ => None,
-    }
+        };
+    };
+    None
 }
 
 #[cfg(target_os = "freebsd")]
-pub fn get_system_dirs(_e_machine: u16, _ei_class: u8) -> Option<search_path::SearchPathVec> {
+pub fn get_system_dirs(
+    _interp: &Option<String>,
+    _e_machine: u16,
+    _ei_class: u8,
+) -> Option<search_path::SearchPathVec> {
     Some(vec![search_path::SearchPath {
         path: "/lib".to_string(),
         dev: 0,
@@ -116,7 +158,11 @@ pub fn get_system_dirs(_e_machine: u16, _ei_class: u8) -> Option<search_path::Se
 }
 
 #[cfg(any(target_os = "openbsd", target_os = "netbsd"))]
-pub fn get_system_dirs(_e_machine: u16, _ei_class: u8) -> Option<search_path::SearchPathVec> {
+pub fn get_system_dirs(
+    _interp: &Option<String>,
+    _e_machine: u16,
+    _ei_class: u8,
+) -> Option<search_path::SearchPathVec> {
     Some(vec![search_path::SearchPath {
         path: "/usr/lib".to_string(),
         dev: 0,
@@ -125,7 +171,11 @@ pub fn get_system_dirs(_e_machine: u16, _ei_class: u8) -> Option<search_path::Se
 }
 
 #[cfg(any(target_os = "illumos", target_os = "solaris"))]
-pub fn get_system_dirs(e_machine: u16, _ei_class: u8) -> Option<search_path::SearchPathVec> {
+pub fn get_system_dirs(
+    _interp: &Option<String>,
+    e_machine: u16,
+    _ei_class: u8,
+) -> Option<search_path::SearchPathVec> {
     match e_machine {
         EM_386 => Some(vec![
             search_path::SearchPath {

--- a/src/elf/system_dirs.rs
+++ b/src/elf/system_dirs.rs
@@ -71,7 +71,12 @@ pub fn get_system_dirs(
     use crate::elf::android;
 
     pub fn get_system_dirs_xx(suffix: &str, is_asan: bool) -> Option<search_path::SearchPathVec> {
-        let add_odm = match android::get_release().unwrap() {
+        let release = match android::get_release() {
+            Ok(release) => release,
+            Err(_) => return None,
+        };
+
+        let add_odm = match release {
             android::AndroidRelease::AndroidR28
             | android::AndroidRelease::AndroidR29
             | android::AndroidRelease::AndroidR30
@@ -83,8 +88,14 @@ pub fn get_system_dirs(
 
         let mut r = search_path::SearchPathVec::new();
         if is_asan {
+            let path = match release {
+                android::AndroidRelease::AndroidR24 | android::AndroidRelease::AndroidR25 => {
+                    format!("/data/lib{}", suffix)
+                }
+                _ => format!("/data/asan/system/lib{}", suffix),
+            };
             r.push(search_path::SearchPath {
-                path: format!("/data/asan/system/lib{}", suffix),
+                path: path,
                 dev: 0,
                 ino: 0,
             });
@@ -109,8 +120,14 @@ pub fn get_system_dirs(
             });
         }
         if is_asan {
+            let path = match release {
+                android::AndroidRelease::AndroidR24 | android::AndroidRelease::AndroidR25 => {
+                    format!("/vendor/lib{}", suffix)
+                }
+                _ => format!("/data/asan/vendor/lib{}", suffix),
+            };
             r.push(search_path::SearchPath {
-                path: format!("/data/asan/vendor/lib{}", suffix),
+                path: path,
                 dev: 0,
                 ino: 0,
             });

--- a/src/pathutils.rs
+++ b/src/pathutils.rs
@@ -13,3 +13,14 @@ pub fn get_name<P: AsRef<Path>>(path: &P) -> String {
         .unwrap_or("")
         .to_string()
 }
+
+#[allow(dead_code)]
+pub fn file_is_under_dir<P1: AsRef<Path>, P2: AsRef<Path>>(file: &P1, dir: &P2) -> bool
+where
+    Path: PartialEq<P2>,
+{
+    if let Some(parent) = file.as_ref().parent() {
+        return parent == dir;
+    }
+    false
+}

--- a/src/pathutils.rs
+++ b/src/pathutils.rs
@@ -13,14 +13,3 @@ pub fn get_name<P: AsRef<Path>>(path: &P) -> String {
         .unwrap_or("")
         .to_string()
 }
-
-#[allow(dead_code)]
-pub fn file_is_under_dir<P1: AsRef<Path>, P2: AsRef<Path>>(file: &P1, dir: &P2) -> bool
-where
-    Path: PartialEq<P2>,
-{
-    if let Some(parent) = file.as_ref().parent() {
-        return parent == dir;
-    }
-    false
-}


### PR DESCRIPTION
Add support for Android, starting from r24 (android 7.0). It is the minimum one that follows what other ELF unixes do (sane default search order, search by SONAME instead of basename, always requires a SONAME, support for DT_RUNPATH) which would not require changing the generic code on elf.rs.